### PR TITLE
Add Firefox Support 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
+
 <html>
   <head>
+    <meta charset=UTF-8>
     <title>Stacks</title>
     <style>
     </style>

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var app = express();
 
 app.engine('.html', require('ejs').renderFile);
-app.use(express.static(path.join(__dirname, '/public')));
+app.use('/static',express.static('static'));
 app.use(require('body-parser').urlencoded({extended: false}));
 
 app.get('/', function(req, res) {

--- a/static/js/Config.js
+++ b/static/js/Config.js
@@ -46,8 +46,8 @@ var State = {
 var Time = {
   CANCELLATION_TIME: 20,
   RANDOM_TIME_THRESHOLD: 1e-3,
-  DEFAULT_MIN_TIME: 1000,
-  MINIMUM_MIN_TIME: 300
+  DEFAULT_MIN_TIME: 100,
+  MINIMUM_MIN_TIME: 10
 };
 
 var setupGeometry = function(canvasWidth, canvasHeight) {

--- a/static/js/GameLogic.js
+++ b/static/js/GameLogic.js
@@ -117,8 +117,8 @@ $(function() {
     var isChrome = !!window.chrome && !!window.chrome.webstore;
     var isSafari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0 || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || safari.pushNotification);
     var mobile = /Mobi/.test(navigator.userAgent);
-    if((!isChrome && !isSafari) || mobile) {
-      $("#status").text("This game is only supported on Google Chrome and Safari for now. Mobile version coming soon.");
+    if(mobile) {
+      $("#status").text("Mobile version coming soon.");
     }
     else {
       $("#explanation").remove();

--- a/views/index.html
+++ b/views/index.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
+
 <html>
   <head>
+    <meta charset=UTF-8>
     <title>Stacks</title>
     <style>
     </style>


### PR DESCRIPTION
`$(window).height()` doesn't behave as expected on Firefox unless you explicitly declare the doctype of the file. These changes resolve that issue. 

As an added benefit, it appears that _stacks_ also works in Microsoft Edge. I've removed the Safari and Chrome checks as a result. 